### PR TITLE
[BUGFIX] Convert entrypoint config to allow multiple entrypoints

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 /composer.lock            export-ignore
 /CONTRIBUTING.md          export-ignore
 /phpstan.php              export-ignore
+/phpstan-baseline.neon    export-ignore
 /phpunit.xml              export-ignore
 /rector.php               export-ignore
 /renovate.json            export-ignore

--- a/README.md
+++ b/README.md
@@ -43,12 +43,16 @@ Enable this extension in your `codeception.yml`:
 extensions:
   enabled:
     - EliasHaeussler\Typo3CodeceptionHelper\Codeception\Extension\ApplicationEntrypointModifier:
-        web-dir: .Build/web
-        main-entrypoint: index.php
-        app-entrypoint: app.php
+        entrypoints:
+          - web-dir: .Build/web
+            main-entrypoint: index.php
+            app-entrypoint: app.php
+          - web-dir: .Build/web/typo3
+            main-entrypoint: index.php
+            app-entrypoint: app.php
 ```
 
-The following config must be provided:
+For each entrypoint, the following config must be provided:
 
 | Config name       | Description                                                                    | Default value |
 |-------------------|--------------------------------------------------------------------------------|---------------|

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^PHPDoc type array\\<string, array\\<int, array\\<string, mixed\\>\\>\\> of property EliasHaeussler\\\\Typo3CodeceptionHelper\\\\Codeception\\\\Extension\\\\ApplicationEntrypointModifier\\:\\:\\$config is not the same as PHPDoc type array\\<int\\|string, mixed\\> of overridden property Codeception\\\\Extension\\:\\:\\$config\\.$#"
+			count: 1
+			path: src/Codeception/Extension/ApplicationEntrypointModifier.php

--- a/phpstan.php
+++ b/phpstan.php
@@ -28,6 +28,7 @@ return PHPStanConfig\Config\Config::create(__DIR__)
         'src',
         'tests',
     )
+    ->withBaseline()
     ->withBleedingEdge()
     ->stubFiles(
         'tests/stubs/Configuration.stub',

--- a/rector.php
+++ b/rector.php
@@ -23,9 +23,10 @@ declare(strict_types=1);
 
 use EliasHaeussler\RectorConfig\Config\Config;
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    Config::create($rectorConfig)
+    Config::create($rectorConfig, PhpVersion::PHP_81)
         ->in(
             __DIR__.'/src',
             __DIR__.'/tests',

--- a/src/ValueObject/Entrypoint.php
+++ b/src/ValueObject/Entrypoint.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-codeception-helper".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3CodeceptionHelper\ValueObject;
+
+use EliasHaeussler\Typo3CodeceptionHelper\Exception;
+use Symfony\Component\Filesystem;
+
+/**
+ * Entrypoint.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class Entrypoint
+{
+    /**
+     * @param non-empty-string $webDirectory
+     * @param non-empty-string $mainEntrypoint
+     * @param non-empty-string $appEntrypoint
+     */
+    public function __construct(
+        private readonly string $webDirectory,
+        private readonly string $mainEntrypoint = 'index.php',
+        private readonly string $appEntrypoint = 'app.php',
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param non-empty-string     $baseDirectory
+     *
+     * @throws Exception\ConfigIsEmpty
+     * @throws Exception\ConfigIsInvalid
+     */
+    public static function fromConfig(array $config, string $baseDirectory): self
+    {
+        $webDirectory = Filesystem\Path::join($baseDirectory, self::parseConfig($config, 'web-dir'));
+        $mainEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'main-entrypoint'));
+        $appEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'app-entrypoint'));
+
+        return new self($webDirectory, $mainEntrypoint, $appEntrypoint);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param non-empty-string     $name
+     *
+     * @return non-empty-string
+     *
+     * @throws Exception\ConfigIsEmpty
+     * @throws Exception\ConfigIsInvalid
+     */
+    private static function parseConfig(array $config, string $name): string
+    {
+        $value = $config[$name] ?? null;
+
+        if (!is_string($value)) {
+            throw new Exception\ConfigIsInvalid($name);
+        }
+        if ('' === $value) {
+            throw new Exception\ConfigIsEmpty($name);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getWebDirectory(): string
+    {
+        return $this->webDirectory;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getMainEntrypoint(): string
+    {
+        return $this->mainEntrypoint;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getAppEntrypoint(): string
+    {
+        return $this->appEntrypoint;
+    }
+}

--- a/tests/src/Codeception/Extension/ApplicationEntrypointModifierTest.php
+++ b/tests/src/Codeception/Extension/ApplicationEntrypointModifierTest.php
@@ -41,6 +41,9 @@ use function sleep;
 #[Framework\Attributes\CoversClass(Src\Codeception\Extension\ApplicationEntrypointModifier::class)]
 final class ApplicationEntrypointModifierTest extends Framework\TestCase
 {
+    /**
+     * @var non-empty-string
+     */
     private string $publicDirectory;
     private Filesystem\Filesystem $filesystem;
     private Src\Codeception\Extension\ApplicationEntrypointModifier $subject;
@@ -55,9 +58,13 @@ final class ApplicationEntrypointModifierTest extends Framework\TestCase
         $this->filesystem = new Filesystem\Filesystem();
         $this->subject = new Src\Codeception\Extension\ApplicationEntrypointModifier(
             [
-                'web-dir' => 'public',
-                'main-entrypoint' => 'index.php',
-                'app-entrypoint' => 'app.php',
+                'entrypoints' => [
+                    [
+                        'web-dir' => 'public',
+                        'main-entrypoint' => 'index.php',
+                        'app-entrypoint' => 'app.php',
+                    ],
+                ],
             ],
             [],
         );
@@ -70,107 +77,15 @@ final class ApplicationEntrypointModifierTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfWebDirectoryIsNotConfigured(): void
+    public function constructorInitializesEntrypoints(): void
     {
-        $this->expectExceptionObject(new Src\Exception\ConfigIsInvalid('web-dir'));
-
-        new Src\Codeception\Extension\ApplicationEntrypointModifier([], []);
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfWebDirectoryIsEmpty(): void
-    {
-        $this->expectExceptionObject(new Src\Exception\ConfigIsEmpty('web-dir'));
-
-        new Src\Codeception\Extension\ApplicationEntrypointModifier(
-            [
-                'web-dir' => '',
-            ],
-            [],
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfMainEntrypointIsNotConfigured(): void
-    {
-        $this->expectExceptionObject(new Src\Exception\ConfigIsInvalid('main-entrypoint'));
-
-        new Src\Codeception\Extension\ApplicationEntrypointModifier(
-            [
-                'web-dir' => 'public',
-                'main-entrypoint' => null,
-            ],
-            [],
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfMainEntrypointIsEmpty(): void
-    {
-        $this->expectExceptionObject(new Src\Exception\ConfigIsEmpty('main-entrypoint'));
-
-        new Src\Codeception\Extension\ApplicationEntrypointModifier(
-            [
-                'web-dir' => 'public',
-                'main-entrypoint' => '',
-            ],
-            [],
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfAppEntrypointIsNotConfigured(): void
-    {
-        $this->expectExceptionObject(new Src\Exception\ConfigIsInvalid('app-entrypoint'));
-
-        new Src\Codeception\Extension\ApplicationEntrypointModifier(
-            [
-                'web-dir' => 'public',
-                'app-entrypoint' => null,
-            ],
-            [],
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfAppEntrypointIsEmpty(): void
-    {
-        $this->expectExceptionObject(new Src\Exception\ConfigIsEmpty('app-entrypoint'));
-
-        new Src\Codeception\Extension\ApplicationEntrypointModifier(
-            [
-                'web-dir' => 'public',
-                'app-entrypoint' => '',
-            ],
-            [],
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorInitializesWebDirectory(): void
-    {
-        self::assertSame(
+        $expected = new Src\ValueObject\Entrypoint(
             $this->publicDirectory,
-            $this->subject->getWebDirectory(),
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorInitializesMainEntrypoint(): void
-    {
-        self::assertSame(
             $this->publicDirectory.'/index.php',
-            $this->subject->getMainEntrypoint(),
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorInitializesAppEntrypoint(): void
-    {
-        self::assertSame(
             $this->publicDirectory.'/app.php',
-            $this->subject->getAppEntrypoint(),
         );
+
+        self::assertEquals([$expected], $this->subject->getEntrypoints());
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/ValueObject/EntrypointTest.php
+++ b/tests/src/ValueObject/EntrypointTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-codeception-helper".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3CodeceptionHelper\Tests\src\ValueObject;
+
+use EliasHaeussler\Typo3CodeceptionHelper as Src;
+use PHPUnit\Framework;
+
+/**
+ * Entrypoint.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\ValueObject\Entrypoint::class)]
+final class EntrypointTest extends Framework\TestCase
+{
+    private Src\ValueObject\Entrypoint $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\ValueObject\Entrypoint('public');
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigThrowsExceptionIfWebDirectoryIsNotConfigured(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\ConfigIsInvalid('web-dir'));
+
+        Src\ValueObject\Entrypoint::fromConfig([], __DIR__);
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigThrowsExceptionIfWebDirectoryIsEmpty(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\ConfigIsEmpty('web-dir'));
+
+        Src\ValueObject\Entrypoint::fromConfig(
+            [
+                'web-dir' => '',
+            ],
+            __DIR__,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigThrowsExceptionIfMainEntrypointIsNotConfigured(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\ConfigIsInvalid('main-entrypoint'));
+
+        Src\ValueObject\Entrypoint::fromConfig(
+            [
+                'web-dir' => 'public',
+                'main-entrypoint' => null,
+            ],
+            __DIR__,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigThrowsExceptionIfMainEntrypointIsEmpty(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\ConfigIsEmpty('main-entrypoint'));
+
+        Src\ValueObject\Entrypoint::fromConfig(
+            [
+                'web-dir' => 'public',
+                'main-entrypoint' => '',
+            ],
+            __DIR__,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigThrowsExceptionIfAppEntrypointIsNotConfigured(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\ConfigIsInvalid('app-entrypoint'));
+
+        Src\ValueObject\Entrypoint::fromConfig(
+            [
+                'web-dir' => 'public',
+                'main-entrypoint' => 'index.php',
+                'app-entrypoint' => null,
+            ],
+            __DIR__,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigThrowsExceptionIfAppEntrypointIsEmpty(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\ConfigIsEmpty('app-entrypoint'));
+
+        Src\ValueObject\Entrypoint::fromConfig(
+            [
+                'web-dir' => 'public',
+                'main-entrypoint' => 'index.php',
+                'app-entrypoint' => '',
+            ],
+            __DIR__,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromConfigReturnsEntrypointFromGivenConfig(): void
+    {
+        $expected = new Src\ValueObject\Entrypoint(
+            __DIR__.'/public',
+            __DIR__.'/public/index.php',
+            __DIR__.'/public/app.php',
+        );
+
+        self::assertEquals(
+            $expected,
+            Src\ValueObject\Entrypoint::fromConfig(
+                [
+                    'web-dir' => 'public',
+                    'main-entrypoint' => 'index.php',
+                    'app-entrypoint' => 'app.php',
+                ],
+                __DIR__,
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getWebDirectoryReturnsWebDirectory(): void
+    {
+        self::assertSame('public', $this->subject->getWebDirectory());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getMainEntrypointReturnsMainEntrypoint(): void
+    {
+        self::assertSame('index.php', $this->subject->getMainEntrypoint());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getAppEntrypointReturnsAppEntrypoint(): void
+    {
+        self::assertSame('app.php', $this->subject->getAppEntrypoint());
+    }
+}


### PR DESCRIPTION
Since extensions cannot be enabled multiple times, even if configuration differs, the entrypoint modifier extension is now rewritten to allow multiple entrypoints.