### PR TITLE
[BUGFIX] Provide defaults for entrypoints when using config

### DIFF
--- a/src/ValueObject/Entrypoint.php
+++ b/src/ValueObject/Entrypoint.php
@@ -26,6 +26,8 @@ namespace EliasHaeussler\Typo3CodeceptionHelper\ValueObject;
 use EliasHaeussler\Typo3CodeceptionHelper\Exception;
 use Symfony\Component\Filesystem;
 
+use function array_key_exists;
+
 /**
  * Entrypoint.
  *
@@ -56,23 +58,28 @@ final class Entrypoint
     public static function fromConfig(array $config, string $baseDirectory): self
     {
         $webDirectory = Filesystem\Path::join($baseDirectory, self::parseConfig($config, 'web-dir'));
-        $mainEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'main-entrypoint'));
-        $appEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'app-entrypoint'));
+        $mainEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'main-entrypoint', 'index.php'));
+        $appEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'app-entrypoint', 'app.php'));
 
         return new self($webDirectory, $mainEntrypoint, $appEntrypoint);
     }
 
     /**
-     * @param array<string, mixed> $config
-     * @param non-empty-string     $name
+     * @param array<string, mixed>  $config
+     * @param non-empty-string      $name
+     * @param non-empty-string|null $default
      *
      * @return non-empty-string
      *
      * @throws Exception\ConfigIsEmpty
      * @throws Exception\ConfigIsInvalid
      */
-    private static function parseConfig(array $config, string $name): string
+    private static function parseConfig(array $config, string $name, string $default = null): string
     {
+        if (!array_key_exists($name, $config) && null !== $default) {
+            return $default;
+        }
+
         $value = $config[$name] ?? null;
 
         if (!is_string($value)) {

--- a/tests/src/Codeception/Extension/ApplicationEntrypointModifierTest.php
+++ b/tests/src/Codeception/Extension/ApplicationEntrypointModifierTest.php
@@ -61,8 +61,6 @@ final class ApplicationEntrypointModifierTest extends Framework\TestCase
                 'entrypoints' => [
                     [
                         'web-dir' => 'public',
-                        'main-entrypoint' => 'index.php',
-                        'app-entrypoint' => 'app.php',
                     ],
                 ],
             ],

--- a/tests/src/ValueObject/EntrypointTest.php
+++ b/tests/src/ValueObject/EntrypointTest.php
@@ -122,6 +122,26 @@ final class EntrypointTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function fromConfigUsesDefaultValuesForEntrypoints(): void
+    {
+        $expected = new Src\ValueObject\Entrypoint(
+            __DIR__.'/public',
+            __DIR__.'/public/index.php',
+            __DIR__.'/public/app.php',
+        );
+
+        self::assertEquals(
+            $expected,
+            Src\ValueObject\Entrypoint::fromConfig(
+                [
+                    'web-dir' => 'public',
+                ],
+                __DIR__,
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function fromConfigReturnsEntrypointFromGivenConfig(): void
     {
         $expected = new Src\ValueObject\Entrypoint(


### PR DESCRIPTION
The behavior of `Entrypoint::fromConfig()` is now streamlined with the constructor. Both methods now use defaults for main entrypoint and app entrypoint, in case they are not configured explicitly.