### PR TITLE
[BUGFIX] Streamline constructon methods of Entrypoint class

### DIFF
--- a/src/ValueObject/Entrypoint.php
+++ b/src/ValueObject/Entrypoint.php
@@ -58,8 +58,8 @@ final class Entrypoint
     public static function fromConfig(array $config, string $baseDirectory): self
     {
         $webDirectory = Filesystem\Path::join($baseDirectory, self::parseConfig($config, 'web-dir'));
-        $mainEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'main-entrypoint', 'index.php'));
-        $appEntrypoint = Filesystem\Path::join($webDirectory, self::parseConfig($config, 'app-entrypoint', 'app.php'));
+        $mainEntrypoint = self::parseConfig($config, 'main-entrypoint', 'index.php');
+        $appEntrypoint = self::parseConfig($config, 'app-entrypoint', 'app.php');
 
         return new self($webDirectory, $mainEntrypoint, $appEntrypoint);
     }
@@ -105,7 +105,7 @@ final class Entrypoint
      */
     public function getMainEntrypoint(): string
     {
-        return $this->mainEntrypoint;
+        return Filesystem\Path::join($this->webDirectory, $this->mainEntrypoint);
     }
 
     /**
@@ -113,6 +113,6 @@ final class Entrypoint
      */
     public function getAppEntrypoint(): string
     {
-        return $this->appEntrypoint;
+        return Filesystem\Path::join($this->webDirectory, $this->appEntrypoint);
     }
 }

--- a/tests/src/Codeception/Extension/ApplicationEntrypointModifierTest.php
+++ b/tests/src/Codeception/Extension/ApplicationEntrypointModifierTest.php
@@ -79,8 +79,8 @@ final class ApplicationEntrypointModifierTest extends Framework\TestCase
     {
         $expected = new Src\ValueObject\Entrypoint(
             $this->publicDirectory,
-            $this->publicDirectory.'/index.php',
-            $this->publicDirectory.'/app.php',
+            'index.php',
+            'app.php',
         );
 
         self::assertEquals([$expected], $this->subject->getEntrypoints());

--- a/tests/src/ValueObject/EntrypointTest.php
+++ b/tests/src/ValueObject/EntrypointTest.php
@@ -126,8 +126,8 @@ final class EntrypointTest extends Framework\TestCase
     {
         $expected = new Src\ValueObject\Entrypoint(
             __DIR__.'/public',
-            __DIR__.'/public/index.php',
-            __DIR__.'/public/app.php',
+            'index.php',
+            'app.php',
         );
 
         self::assertEquals(
@@ -146,8 +146,8 @@ final class EntrypointTest extends Framework\TestCase
     {
         $expected = new Src\ValueObject\Entrypoint(
             __DIR__.'/public',
-            __DIR__.'/public/index.php',
-            __DIR__.'/public/app.php',
+            'index.php',
+            'app.php',
         );
 
         self::assertEquals(
@@ -172,12 +172,12 @@ final class EntrypointTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function getMainEntrypointReturnsMainEntrypoint(): void
     {
-        self::assertSame('index.php', $this->subject->getMainEntrypoint());
+        self::assertSame('public/index.php', $this->subject->getMainEntrypoint());
     }
 
     #[Framework\Attributes\Test]
     public function getAppEntrypointReturnsAppEntrypoint(): void
     {
-        self::assertSame('app.php', $this->subject->getAppEntrypoint());
+        self::assertSame('public/app.php', $this->subject->getAppEntrypoint());
     }
 }


### PR DESCRIPTION
The two construction methods `Entrypoint::__construct()` and `Entrypoint::fromConfig()` behaved differently for both entrypoint properties. In case the default constructor is used, the path was treated as relative to the web directory, whereas the static constructor method stored them as absolute paths.

This is now resolved and both entrypoints are always stored as paths relative to the web directory.