### PR TITLE
[TASK] Stabilize backend login

### DIFF
--- a/src/Codeception/Module/Backend.php
+++ b/src/Codeception/Module/Backend.php
@@ -69,6 +69,7 @@ final class Backend extends Module
         $I->fillField(Enums\Selectors::BackendLoginPasswordField->value, $password);
         $I->click(Enums\Selectors::BackendLoginSubmitButton->value);
         $I->waitForElementNotVisible(Enums\Selectors::BackendLoginForm->value);
+        $I->waitForElementNotVisible(Enums\Selectors::BackendProgressBar->value);
         $I->seeCookie('be_typo_user');
     }
 

--- a/src/Enums/Selectors.php
+++ b/src/Enums/Selectors.php
@@ -32,9 +32,10 @@ namespace EliasHaeussler\Typo3CodeceptionHelper\Enums;
 enum Selectors: string
 {
     case BackendContentFrame = '#typo3-contentIframe';
-    case BackendModuleWrapper = '.module';
     case BackendLoginForm = '#typo3-login-form';
     case BackendLoginPasswordField = '#t3-password';
     case BackendLoginSubmitButton = '#t3-login-submit';
     case BackendLoginUsernameField = '#t3-username';
+    case BackendModuleWrapper = '.module';
+    case BackendProgressBar = '#nprogress';
 }

--- a/tests/src/Codeception/Module/BackendTest.php
+++ b/tests/src/Codeception/Module/BackendTest.php
@@ -57,7 +57,7 @@ final class BackendTest extends Framework\TestCase
         $this->webDriver->expects(self::exactly(2))->method('waitForElementVisible');
         $this->webDriver->expects(self::exactly(2))->method('fillField');
         $this->webDriver->expects(self::once())->method('click');
-        $this->webDriver->expects(self::once())->method('waitForElementNotVisible');
+        $this->webDriver->expects(self::exactly(2))->method('waitForElementNotVisible');
         $this->webDriver->expects(self::once())->method('seeCookie');
 
         $this->subject->login('admin', 'password');
@@ -80,7 +80,7 @@ final class BackendTest extends Framework\TestCase
         $this->webDriver->expects(self::exactly(2))->method('waitForElementVisible');
         $this->webDriver->expects(self::exactly(2))->method('fillField');
         $this->webDriver->expects(self::once())->method('click');
-        $this->webDriver->expects(self::once())->method('waitForElementNotVisible');
+        $this->webDriver->expects(self::exactly(2))->method('waitForElementNotVisible');
         $this->webDriver->expects(self::once())->method('seeCookie');
 
         $this->subject->loginAs('admin');


### PR DESCRIPTION
This pull request includes improvements to the login process in the `Backend` module and updates to the `Selectors` enum. The most important changes are as follows:

Improvements to login process:

* [`src/Codeception/Module/Backend.php`](diffhunk://#diff-fa4eef3820d44e69cd15b9879bc666b55d2405949bb29aeeb7dce56a74ef4aafR72): Added a wait condition to ensure the backend progress bar is not visible before proceeding, which improves the reliability of the login process.

Updates to `Selectors` enum:

* [`src/Enums/Selectors.php`](diffhunk://#diff-b20c2d37e7edb1c886e4178cebe2389a7c9abbdfc360b9a861f3a257312bf21dL35-R40): Added `BackendProgressBar` selector to handle the new wait condition in the login process.